### PR TITLE
Add link to linked source code to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Uploaded for research purposes and so we can develop IoT and such.
 See "ForumPost.txt" or [ForumPost.md](ForumPost.md) for the post in which it
 leaks, if you want to know how it is all set up and the likes.
 
+You can also explore the [source with jump-to-def, find-refs, and symbol
+search](https://sourcegraph.com/github.com/jgamblin/Mirai-Source-Code/-/blob/mirai/bot/attack.c#L44:6).
+
 ## Requirements
 * gcc
 * golang


### PR DESCRIPTION
Thanks for posting this—this has been incredibly interesting to dig through and understand. It's quickly become one of the primary topics of discussion among my broader circle of friends.

This PR adds a link to the code as indexed by Sourcegraph, allowing readers to jump to def, find refs, and search for symbols when viewing the code in their browser. (Full disclosure: I'm one of the creators of the tool.) It's been helpful when sharing and pointing out specific parts of the code to friends, so I thought I'd open a PR to add it to the README, since others trying to dig through the code might find it useful.

Thanks again for posting!
