### PR TITLE
docs: fix simple typo, sequense -> sequence

### DIFF
--- a/mirai/bot/includes.h
+++ b/mirai/bot/includes.h
@@ -56,11 +56,11 @@ static void xvprintf(const char *fmt, va_list arp)
 	for (;;) {
 		c = *fmt++;					/* Get a char */
 		if (!c) break;				/* End of format? */
-		if (c != '%') {				/* Pass through it if not a % sequense */
+		if (c != '%') {				/* Pass through it if not a % sequence */
 			xputc(c); continue;
 		}
 		f = 0;
-		c = *fmt++;					/* Get first char of the sequense */
+		c = *fmt++;					/* Get first char of the sequence */
 		if (c == '0') {				/* Flag: '0' padded */
 			f = 1; c = *fmt++;
 		} else {

--- a/mirai/bot/includes.h
+++ b/mirai/bot/includes.h
@@ -56,7 +56,7 @@ static void xvprintf(const char *fmt, va_list arp)
 	for (;;) {
 		c = *fmt++;					/* Get a char */
 		if (!c) break;				/* End of format? */
-		if (c != '%') {				/* Pass through it if not a % sequence */
+		if (c != '%') {				/* Pass it through if not a % sequence */
 			xputc(c); continue;
 		}
 		f = 0;


### PR DESCRIPTION
There is a small typo in mirai/bot/includes.h.

Should read `sequence` rather than `sequense`.

